### PR TITLE
changed request to ignore cert errors and do something with the results

### DIFF
--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -65,6 +65,8 @@ public class BurpExtender implements IBurpExtender, IContextMenuFactory, Clipboa
 
     private void copyMessages(IHttpRequestResponse[] messages) {
         StringBuilder node = new StringBuilder("var request = require('request');\n");
+        // disable cert checks so things like self-signed certs work
+        node.append("process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0");
         int i = 0;
         // Generate a new request for every regular http request
         for (IHttpRequestResponse message : messages) {
@@ -99,7 +101,7 @@ public class BurpExtender implements IBurpExtender, IContextMenuFactory, Clipboa
             }
             node.append("}");
             //Generate a unique request for each one
-            node.append("\nrequest(").append(prefix).append("options)\n\n");
+            node.append("\nrequest(").append(prefix).append("options, function (error, response, body) {\nconsole.log('statusCode:', response && response.statusCode)\nconsole.log('error: ', error)\nconsole.log('body: ', body)\n})\n\n");
         }
 
         Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(node.toString()), this);


### PR DESCRIPTION
Arguably the console.log stuff isn't needed, but since this particular extension is one I use most often when providing clients an example, I find myself adding that every time.

The cert thing is probably just a good idea to have in general, as it can be tricky figuring out how to get node request to ignore invalid certs.

Initially added the PR to the Portswigger fork because I wasn't paying attention to where the source was from. Sorry about that. Portswigger pointed me back upstream.